### PR TITLE
Added Unicode category support

### DIFF
--- a/src/js/parser/javascript/escape.js
+++ b/src/js/parser/javascript/escape.js
@@ -84,5 +84,27 @@ export default {
   },
   u() {
     return [`U+${this.arg.toUpperCase()}`, parseInt(this.arg, 16), false];
+  },
+  p() {
+    var arg = this.arg;
+    var map = {
+        'L': 'Letter', 'Ll': 'Lowercase_Letter', 'Lu': 'Uppercase_Letter', 'Lt': 'Titlecase_Letter',
+        'L&': 'Cased_Letter', 'Lm': 'Modifier_Letter', 'Lo': 'Other_Letter', 'M': 'Mark', 'Mn': 'Non_Spacing_Mark',
+        'Mc': 'Spacing_Combining_Mark', 'Me': 'Enclosing_Mark', 'Z': 'Separator', 'Zs': 'Space_Separator',
+        'Zl': 'Line_Separator', 'Zp': 'Paragraph_Separator', 'S': 'Symbol', 'Sm': 'Math_Symbol',
+        'Sc': 'Currency_Symbol', 'Sk': 'Modifier_Symbol', 'So': 'Other_Symbol', 'N': 'Number',
+        'Nd': 'Decimal_Digit_Number', 'Nl': 'Letter_Number', 'No': 'Other_Number', 'P': 'Punctuation',
+        'Pd': 'Dash_Punctuation', 'Ps': 'Open_Punctuation', 'Pe': 'Close_Punctuation', 'Pi': 'Initial_Punctuation',
+        'Pf': 'Final_Punctuation', 'Pc': 'Connector_Punctuation', 'Po': 'Other_Punctuation', 'C': 'Other',
+        'Cc': 'Control', 'Cf': 'Format', 'Co': 'Private_Use', 'Cs': 'Surrogate', 'Cn': 'Unassigned'
+    };
+    var temp = map[arg];
+    if (temp) {
+        arg = temp;
+    }
+    if (arg.slice(0, 2) == 'In') {
+        arg = 'in '+arg.slice(2);
+    }
+    return [arg.replace(/_/g, ' '), -1, false];
   }
 };

--- a/src/js/parser/javascript/escape.js
+++ b/src/js/parser/javascript/escape.js
@@ -14,6 +14,28 @@ function hex(value) {
   return `(0x${str})`;
 }
 
+function unicodeProperty(arg) {
+    var map = {
+        'L': 'Letter', 'Ll': 'Lowercase_Letter', 'Lu': 'Uppercase_Letter', 'Lt': 'Titlecase_Letter',
+        'L&': 'Cased_Letter', 'Lm': 'Modifier_Letter', 'Lo': 'Other_Letter', 'M': 'Mark', 'Mn': 'Non_Spacing_Mark',
+        'Mc': 'Spacing_Combining_Mark', 'Me': 'Enclosing_Mark', 'Z': 'Separator', 'Zs': 'Space_Separator',
+        'Zl': 'Line_Separator', 'Zp': 'Paragraph_Separator', 'S': 'Symbol', 'Sm': 'Math_Symbol',
+        'Sc': 'Currency_Symbol', 'Sk': 'Modifier_Symbol', 'So': 'Other_Symbol', 'N': 'Number',
+        'Nd': 'Decimal_Digit_Number', 'Nl': 'Letter_Number', 'No': 'Other_Number', 'P': 'Punctuation',
+        'Pd': 'Dash_Punctuation', 'Ps': 'Open_Punctuation', 'Pe': 'Close_Punctuation', 'Pi': 'Initial_Punctuation',
+        'Pf': 'Final_Punctuation', 'Pc': 'Connector_Punctuation', 'Po': 'Other_Punctuation', 'C': 'Other',
+        'Cc': 'Control', 'Cf': 'Format', 'Co': 'Private_Use', 'Cs': 'Surrogate', 'Cn': 'Unassigned'
+    };
+    var temp = map[arg];
+    if (temp) {
+        arg = temp;
+    }
+    if (arg.slice(0, 2) == 'In') {
+        arg = 'in '+arg.slice(2);
+    }
+    return arg.replace(/_/g, ' ');
+}
+
 export default {
   type: 'escape',
 
@@ -86,25 +108,9 @@ export default {
     return [`U+${this.arg.toUpperCase()}`, parseInt(this.arg, 16), false];
   },
   p() {
-    var arg = this.arg;
-    var map = {
-        'L': 'Letter', 'Ll': 'Lowercase_Letter', 'Lu': 'Uppercase_Letter', 'Lt': 'Titlecase_Letter',
-        'L&': 'Cased_Letter', 'Lm': 'Modifier_Letter', 'Lo': 'Other_Letter', 'M': 'Mark', 'Mn': 'Non_Spacing_Mark',
-        'Mc': 'Spacing_Combining_Mark', 'Me': 'Enclosing_Mark', 'Z': 'Separator', 'Zs': 'Space_Separator',
-        'Zl': 'Line_Separator', 'Zp': 'Paragraph_Separator', 'S': 'Symbol', 'Sm': 'Math_Symbol',
-        'Sc': 'Currency_Symbol', 'Sk': 'Modifier_Symbol', 'So': 'Other_Symbol', 'N': 'Number',
-        'Nd': 'Decimal_Digit_Number', 'Nl': 'Letter_Number', 'No': 'Other_Number', 'P': 'Punctuation',
-        'Pd': 'Dash_Punctuation', 'Ps': 'Open_Punctuation', 'Pe': 'Close_Punctuation', 'Pi': 'Initial_Punctuation',
-        'Pf': 'Final_Punctuation', 'Pc': 'Connector_Punctuation', 'Po': 'Other_Punctuation', 'C': 'Other',
-        'Cc': 'Control', 'Cf': 'Format', 'Co': 'Private_Use', 'Cs': 'Surrogate', 'Cn': 'Unassigned'
-    };
-    var temp = map[arg];
-    if (temp) {
-        arg = temp;
-    }
-    if (arg.slice(0, 2) == 'In') {
-        arg = 'in '+arg.slice(2);
-    }
-    return [arg.replace(/_/g, ' '), -1, false];
+    return [unicodeProperty(this.arg), -1, false];
+  },
+  P() {
+    return ['non-'+unicodeProperty(this.arg), -1, false];
   }
 };

--- a/src/js/parser/javascript/grammar.peg
+++ b/src/js/parser/javascript/grammar.peg
@@ -25,14 +25,16 @@ grammar JavascriptRegexp
        / octal_escape
        / hex_escape
        / unicode_escape
-       / null_escape )
+       / null_escape
+       / unicode_category_escape )
   charset_range_escape <- "\\" esc:(
          code:[bfnrtv] arg:""?
        / control_escape
        / octal_escape
        / hex_escape
        / unicode_escape
-       / null_escape )
+       / null_escape
+       / unicode_category_escape )
   charset_literal <- ( ""? literal:[^\\\]] )
                    / ( literal:"\\" &"c" )
                    / ( "\\" literal:[^bdDfnrsStvwW] )
@@ -45,7 +47,8 @@ grammar JavascriptRegexp
        / octal_escape
        / hex_escape
        / unicode_escape
-       / null_escape )
+       / null_escape
+       / unicode_category_escape )
   literal <- ( ""? literal:[^|\\/.\[\(\)?+*$^] )
            / ( literal:"\\" &"c" )
            / ( "\\" literal:. )
@@ -55,3 +58,4 @@ grammar JavascriptRegexp
   hex_escape <- code:"x" arg:( [0-9a-fA-F] [0-9a-fA-F] )
   unicode_escape <- code:"u" arg:( [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] )
   null_escape <- code:"0" arg:""?
+  unicode_category_escape <- code:"p" "{" arg:([_0-9a-zA-Z-]+) "}"

--- a/src/js/parser/javascript/grammar.peg
+++ b/src/js/parser/javascript/grammar.peg
@@ -26,7 +26,8 @@ grammar JavascriptRegexp
        / hex_escape
        / unicode_escape
        / null_escape
-       / unicode_category_escape )
+       / unicode_category_escape
+       / non_unicode_category_escape )
   charset_range_escape <- "\\" esc:(
          code:[bfnrtv] arg:""?
        / control_escape
@@ -34,7 +35,8 @@ grammar JavascriptRegexp
        / hex_escape
        / unicode_escape
        / null_escape
-       / unicode_category_escape )
+       / unicode_category_escape
+       / non_unicode_category_escape )
   charset_literal <- ( ""? literal:[^\\\]] )
                    / ( literal:"\\" &"c" )
                    / ( "\\" literal:[^bdDfnrsStvwW] )
@@ -48,7 +50,8 @@ grammar JavascriptRegexp
        / hex_escape
        / unicode_escape
        / null_escape
-       / unicode_category_escape )
+       / unicode_category_escape
+       / non_unicode_category_escape )
   literal <- ( ""? literal:[^|\\/.\[\(\)?+*$^] )
            / ( literal:"\\" &"c" )
            / ( "\\" literal:. )
@@ -59,3 +62,4 @@ grammar JavascriptRegexp
   unicode_escape <- code:"u" arg:( [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] )
   null_escape <- code:"0" arg:""?
   unicode_category_escape <- code:"p" "{" arg:([_0-9a-zA-Z-]+) "}"
+  non_unicode_category_escape <- code:"P" "{" arg:([_0-9a-zA-Z-]+) "}"


### PR DESCRIPTION
I added support for Unicode categories, as listed on [this site](http://www.regular-expressions.info/unicode.html#category), e.g. `\p{P}` for punctuation or `\p{Cherokee}` for Cherokee characters. I'm not sure how you would actually want to do this, so I just went for it. It doesn't verify to make sure that the value used and just assumes it is available. And it uses some heuristics to try and format it properly.

If you'd rather, all possible values could be added to the grammar, and then there could be a big map to the descriptions of each one.