### PR TITLE
Fix exposing the error

### DIFF
--- a/src/js/util.js
+++ b/src/js/util.js
@@ -119,9 +119,9 @@ function tick() {
 //
 // - __error__ - Error/exception object to be re-thrown to the browser.
 function exposeError(error) {
-  tick().then(() => {
+  setTimeout(() => {
     throw error;
-  });
+  }, 0);
 }
 
 export default {


### PR DESCRIPTION
Using a promise for the setTimeout call is broken in this case, as the error would again be thrown in a promise operation, and so not exposed