### PR TITLE
fixed off-by-one issue in repeat label

### DIFF
--- a/spec/parser/javascript/repeat_spec.js
+++ b/spec/parser/javascript/repeat_spec.js
@@ -47,6 +47,13 @@ describe('parser/javascript/repeat.js', function() {
       hasSkip: true,
       hasLoop: false
     },
+    '{0}': {
+      minimum: 0,
+      maximum: 0,
+      greedy: true,
+      hasSkip: true,
+      hasLoop: false
+    },
     '{1}': {
       minimum: 1,
       maximum: 1,
@@ -198,49 +205,54 @@ describe('parser/javascript/repeat.js', function() {
 
     _.each([
       {
-        minimum: 1,
+        minimum: 0,
         maximum: -1,
         label: undefined
       },
       {
-        minimum: 2,
+        minimum: 1,
         maximum: -1,
         label: '1+ times'
       },
       {
         minimum: 3,
         maximum: -1,
-        label: '2+ times'
+        label: '3+ times'
       },
       {
         minimum: 0,
-        maximum: 2,
+        maximum: 0,
+        label: undefined
+      },
+      {
+        minimum: 0,
+        maximum: 1,
         label: 'at most once'
       },
       {
         minimum: 0,
-        maximum: 3,
+        maximum: 2,
         label: 'at most 2 times'
       },
       {
-        minimum: 2,
-        maximum: 2,
+        minimum: 1,
+        maximum: 1,
         label: 'once'
       },
       {
         minimum: 3,
         maximum: 3,
-        label: '2 times'
+        label: '3 times'
+      },
+      {
+        minimum: 1,
+        maximum: 2,
+        label: '1\u{2026}2 times'
       },
       {
         minimum: 2,
         maximum: 3,
-        label: '1\u20262 times'
-      },
-      {
-        minimum: 3,
-        maximum: 4,
-        label: '2\u20263 times'
+        label: '2\u{2026}3 times'
       }
 
     ], t => {

--- a/src/js/parser/javascript/repeat.js
+++ b/src/js/parser/javascript/repeat.js
@@ -33,14 +33,17 @@ export default {
     label: {
       get: function() {
         if (this.minimum === this.maximum) {
-          return formatTimes(this.minimum - 1);
-        } else if (this.minimum <= 1 && this.maximum >= 2) {
-          return `at most ${formatTimes(this.maximum - 1)}`;
-        } else if (this.minimum >= 2) {
+          if (this.minimum === 0) {
+            return undefined;
+          }
+          return formatTimes(this.minimum);
+        } else if (this.minimum <= 0 && this.maximum >= 1) {
+          return `at most ${formatTimes(this.maximum)}`;
+        } else if (this.minimum >= 1) {
           if (this.maximum === -1) {
-            return `${this.minimum - 1}+ times`;
+            return `${this.minimum}+ times`;
           } else {
-            return `${this.minimum - 1}\u2026${formatTimes(this.maximum - 1)}`;
+            return `${this.minimum}\u{2026}${formatTimes(this.maximum)}`;
           }
         }
       }


### PR DESCRIPTION
Previously, patterns like '{2}' would be labelled 'once',
and '{0}' could end up as '-1 Times'.
The repeat-label logic was adjusted, along with special
handling for the non-sensical '{0}' case.
Also I am not quite sure how it should be visualized, right
now 'a{0}' looks nearly similar to 'a?', even though it is
quite different effectively.

Fixes #19