### PR TITLE
'{0}' label is not shown anymore

### DIFF
--- a/spec/parser/javascript/repeat_spec.js
+++ b/spec/parser/javascript/repeat_spec.js
@@ -54,6 +54,13 @@ describe('parser/javascript/repeat.js', function() {
       hasSkip: false,
       hasLoop: false
     },
+    '{0}': {
+      minimum: 0,
+      maximum: 0,
+      greedy: true,
+      hasSkip: true,
+      hasLoop: false
+    },
     '{1}?': {
       minimum: 1,
       maximum: 1,
@@ -200,6 +207,11 @@ describe('parser/javascript/repeat.js', function() {
       {
         minimum: 1,
         maximum: -1,
+        label: undefined
+      },
+      {
+        minimum: 0,
+        maximum: 0,
         label: undefined
       },
       {

--- a/src/js/parser/javascript/repeat.js
+++ b/src/js/parser/javascript/repeat.js
@@ -33,6 +33,9 @@ export default {
     label: {
       get: function() {
         if (this.minimum === this.maximum) {
+          if (this.minimum === 0) {
+            return undefined;
+          }
           return formatTimes(this.minimum - 1);
         } else if (this.minimum <= 1 && this.maximum >= 2) {
           return `at most ${formatTimes(this.maximum - 1)}`;


### PR DESCRIPTION
Previously, '{0}' would be labelled as '-1 Times', which is not actually the case.
Also I am not sure to best visualize such a pattern, right now, except for the label,
'a{0}' looks similar to 'a?', even though they don't have the same effect.