### PR TITLE
configure Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - "4.1"
 before_script:
   - npm install -g gulp
-script: gulp karma:single
+script: gulp verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "4.1"
+before_script:
+  - npm install -g gulp
+script: gulp karma:single

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,13 @@ module.exports = function(karma) {
   var globs = _.flatten([
     config.globs.js,
     config.globs.spec
-  ]);
+  ]),
+    browser = 'Chrome';
+
+  if (process.env.TRAVIS) {
+    globs.unshift('node_modules/babel-polyfill/dist/polyfill.js');
+    browser = 'PhantomJS';
+  }
 
   karma.set({
     frameworks: ['browserify', 'jasmine'],
@@ -17,7 +23,7 @@ module.exports = function(karma) {
     reporters: ['progress', 'notify'],
     colors: true,
     logLevel: karma.LOG_INFO,
-    browsers: ['Chrome'],
+    browsers: [browser],
     autoWatch: true,
     singleRun: false,
     browserify: _.extend({

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "karma-chrome-launcher": "^0.2.2",
     "karma-jasmine": "^0.3.1",
     "karma-notify-reporter": "^0.1.1",
+    "karma-phantomjs-launcher": "^0.2.2",
     "lodash": "^3.10.1",
     "node-bourbon": "^4.2.3",
     "snapsvg": "^0.4.0",


### PR DESCRIPTION
Considering this project has an awesome test-suite, I thought it would be fitting to automatically run it when new PR's come in, or when a change is pushed/merged in any way.

When configured, travis itself could look [something like this](https://travis-ci.org/Byron/regexper-static/builds/99982180) - as you can see, one test is still failing, as apparently a spy cannot be installed on `window.addEventListener` in *PhantomJS*. Maybe you have an idea ... . When this is working, you could add a badge to your readme too, ideally it is greener than this one: [![Build Status](https://travis-ci.org/Byron/regexper-static.svg?branch=travis-ci)](https://travis-ci.org/Byron/regexper-static).

To make travis work with this repository, you would probably have to follow [the first portion of this guide](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A) to link your travis account with your github one. Then you can enable a [travis webhook of this repository](https://developer.github.com/webhooks/creating/#setting-up-a-webhook) to trigger travis whenever something happens. Maybe it can also work without the first step, I am not quite sure. Considering that [regexper](https://github.com/javallone/regexper) already uses travis, this should probably be setup easily.

I hope you find this as useful as I did, back in the days when someone created a Travis PR for one of my projects :).