### PR TITLE
Loop label tooltip. Fix #14

### DIFF
--- a/spec/parser/javascript/repeat_spec.js
+++ b/spec/parser/javascript/repeat_spec.js
@@ -265,6 +265,74 @@ describe('parser/javascript/repeat.js', function() {
 
   });
 
+  describe('tooltip property', function() {
+
+    beforeEach(function() {
+      this.node = new javascript.Parser('*').__consume__repeat();
+    });
+
+    _.each([
+      {
+        minimum: 1,
+        maximum: -1,
+        tooltip: undefined
+      },
+      {
+        minimum: 0,
+        maximum: 0,
+        tooltip: undefined
+      },
+      {
+        minimum: 2,
+        maximum: -1,
+        tooltip: 'repeats 2+ times in total'
+      },
+      {
+        minimum: 3,
+        maximum: -1,
+        tooltip: 'repeats 3+ times in total'
+      },
+      {
+        minimum: 0,
+        maximum: 2,
+        tooltip: 'repeats at most 2 times in total'
+      },
+      {
+        minimum: 0,
+        maximum: 3,
+        tooltip: 'repeats at most 3 times in total'
+      },
+      {
+        minimum: 2,
+        maximum: 2,
+        tooltip: 'repeats 2 times in total'
+      },
+      {
+        minimum: 3,
+        maximum: 3,
+        tooltip: 'repeats 3 times in total'
+      },
+      {
+        minimum: 2,
+        maximum: 3,
+        tooltip: 'repeats 2\u20263 times in total'
+      },
+      {
+        minimum: 3,
+        maximum: 4,
+        tooltip: 'repeats 3\u20264 times in total'
+      }
+
+    ], t => {
+      it(`is "${t.tooltip}" when minimum=${t.minimum} and maximum=${t.maximum}`, function() {
+        this.node.minimum = t.minimum;
+        this.node.maximum = t.maximum;
+        expect(this.node.tooltip).toEqual(t.tooltip);
+      });
+    });
+
+  });
+
   describe('#skipPath', function() {
 
     beforeEach(function() {

--- a/src/js/parser/javascript/match_fragment.js
+++ b/src/js/parser/javascript/match_fragment.js
@@ -53,11 +53,18 @@ export default {
   // be matched.
   loopLabel() {
     var labelStr = this.repeat.label,
-        label, labelBox, box;
+        tooltipStr = this.repeat.tooltip,
+        label, tooltip, labelBox, box;
 
     if (labelStr) {
       label = this.container.text(0, 0, [labelStr])
         .addClass('repeat-label');
+
+      if (tooltipStr) {
+        tooltip = Snap().el('title')
+          .append(this.container.text(0, 0, tooltipStr));
+        label.append(tooltip);
+      }
 
       box = this.getBBox();
       labelBox = label.getBBox();

--- a/src/js/parser/javascript/repeat.js
+++ b/src/js/parser/javascript/repeat.js
@@ -47,6 +47,31 @@ export default {
           }
         }
       }
+    },
+
+    // Tooltip to place of loop path label to provide further details.
+    tooltip: {
+      get: function() {
+        let repeatCount;
+        if (this.minimum === this.maximum) {
+          if (this.minimum === 0) {
+            repeatCount = undefined;
+          } else {
+            repeatCount = formatTimes(this.minimum);
+          }
+        } else if (this.minimum <= 1 && this.maximum >= 2) {
+          repeatCount = `at most ${formatTimes(this.maximum)}`;
+        } else if (this.minimum >= 2) {
+          if (this.maximum === -1) {
+            repeatCount = `${this.minimum}+ times`;
+          } else {
+            repeatCount = `${this.minimum}\u2026${formatTimes(this.maximum)}`;
+          }
+        }
+
+        console.log(repeatCount, this.minimum, this.maximum);
+        return repeatCount ? `repeats ${repeatCount} in total` : repeatCount;
+      }
     }
   },
 

--- a/src/sass/svg.scss
+++ b/src/sass/svg.scss
@@ -50,6 +50,10 @@ circle {
   font-size: 10px;
 }
 
+.repeat-label {
+    cursor: help;
+}
+
 .subexp .subexp-label tspan,
 .charset .charset-label tspan {
   dominant-baseline: text-after-edge;


### PR DESCRIPTION
__TL;DR;__

Better implementation of what was detailed in https://github.com/javallone/regexper-static/issues/14#issuecomment-235414864.

-----------------

Adds an unobtrusive tooltip - the standard HTML tooltip displayed by the `title` attribute in HTML, and `<title>` tag in SVG. The text of that tooltip doesn't have to be as concise as the label on the diagram, and can thus explain exactly what the label means, hopefully clearing the "is the label describing the repetition or the path?" confusion.

Visual result:

![tooltip-demo](https://cloud.githubusercontent.com/assets/877585/17156370/2a5e47ee-5392-11e6-9279-d0009b0ff3a8.gif)

Notice that the presence of the tooltip is only conveyed by the mouse cursor set to `help` – which is a clue, but quite an obscure one. It's not the best solution, but it is fairly simple to implement and I don't think it comes with drawbacks.

Browser support - I tried this on Chrome, Safari, Firefox on OSX, IE 11 on Windows 8, & iOS Safari. It works fine in all the desktop browsers, and is not rendered in iOS Safari (as expected).